### PR TITLE
Proposed change to the point of view of 3 principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ We comply with data regulations, such as GDPR, and automate these processes.
 
 We work to minimize obstacles that can impact any team’s ability to achieve their goals.
 
-Teams should have the capability, flexibility, and can-do attitude to tackle any work needed to progress.
+We, as teams, have the capability, flexibility, and can-do attitude to tackle any work needed to progress.
 
-They should build platforms and codebases that are accessible to all.
+We, as teams, build platforms and codebases that are accessible to all.
 
-Communication is vital; the owning team should always have awareness of changes, and priority should be given to unblocking any work on their systems.
+Communication is vital; as teams we always have awareness of changes, and priority should be given to unblocking any work on our systems.
 
 We document our code/services to ensure they are accessible to others.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We, as teams, have the capability, flexibility, and can-do attitude to tackle an
 
 We, as teams, build platforms and codebases that are accessible to all.
 
-Communication is vital; as teams we always have awareness of changes, and priority should be given to unblocking any work on our systems.
+Communication is vital; as teams we always have awareness of changes, and priority is given to unblocking any work on our systems.
 
 We document our code/services to ensure they are accessible to others.
 


### PR DESCRIPTION
There are 3 principles, within the *"Minimise blockers and dependencies"* section, that are written from something more like an "outside" perspective. The rest of the document is worded as something *we* have written and that *we* stand by.

The 3 principles I've edited here read more like a rule handed down from somewhere outwith of engineering.

I propose we word them so they read as if we own them.

I've also added a shift away from a wording that was akin to "they don't do this, but they should", to "we act to embody this".